### PR TITLE
Added option to not "lock" the modules when hidden.

### DIFF
--- a/MMM-ModuleScheduler.js
+++ b/MMM-ModuleScheduler.js
@@ -17,6 +17,7 @@ Module.register("MMM-ModuleScheduler",{
         notification_schedule: false,
         global_schedule: false,
         debug: true,
+		uselock: true,
     },
 
     // Define start sequence.
@@ -98,7 +99,11 @@ Module.register("MMM-ModuleScheduler",{
 
     setModuleDisplay: function(module, action, brightness){
         var self = this;
-        var options = {lockString: this.identifier};
+		if (self.config.uselock){
+			var options = {lockString: this.identifier};
+		} else {
+			var options = "";
+		}
         Log.log(this.name + " is processing the " + action + (action === "DIM_MODULE" ? " (" + brightness + "%)" : "") + " request for " + module.identifier );
 
         var moduleDiv = document.getElementById(module.identifier);

--- a/MMM-ModuleScheduler.js
+++ b/MMM-ModuleScheduler.js
@@ -99,10 +99,9 @@ Module.register("MMM-ModuleScheduler",{
 
     setModuleDisplay: function(module, action, brightness){
         var self = this;
+		var options = "";
 		if (self.config.uselock){
-			var options = {lockString: this.identifier};
-		} else {
-			var options = "";
+			options = {lockString: this.identifier};
 		}
         Log.log(this.name + " is processing the " + action + (action === "DIM_MODULE" ? " (" + brightness + "%)" : "") + " request for " + module.identifier );
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,17 @@ To schedule the sending of a notification to other modules, add a `notification_
 * `payload` is optional and its contents will be determined by the module receiving the notification. 
 
 * When specifying your cron values you'll need to make sure that your values fall within the ranges. For instance, some cron's use a 0-7 range for the day of week where both 0 and 7 represent Sunday. We do not. And that is an optimisation.
+
+
 | **Unit** | **Format** |
 | --- | --- |
-| Seconds | 0-59 |
-| Minutes | 0-59 |
-| Hours | 0-23 |
-| Day of Month | 1-31 |
-| Months | 0-11 (Jan-Dec) |
-| Day of Week | 0-6 (Sun-Sat) |
+| `Seconds` | 0-59 |
+| `Minutes` | 0-59 |
+| `Hours` | 0-23 |
+| `Day of Month` | 1-31 |
+| `Months` | 0-11 (Jan-Dec) |
+| `Day of Week` | 0-6 (Sun-Sat) |
+
 
 #### Scheduling Multiple Notifications
 Multiple `notification_schedule` definitions can be added using an array, e.g.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To schedule the sending of a notification to other modules, add a `notification_
 * `schedule` is required and determines when the notification will be sent. It should be a valid cron expression - see [crontab.guru](http://crontab.guru/). 
 * `payload` is optional and its contents will be determined by the module receiving the notification. 
 
-* When specifying your cron values you'll need to make sure that your values fall within the ranges. For instance, some cron's use a 0-7 range for the day of week where both 0 and 7 represent Sunday. We do not. And that is an optimisation.
+* When specifying your schedule values make sure that your values fall within the ranges below.
 
 
 | **Unit** | **Format** |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ To schedule the sending of a notification to other modules, add a `notification_
 * `schedule` is required and determines when the notification will be sent. It should be a valid cron expression - see [crontab.guru](http://crontab.guru/). 
 * `payload` is optional and its contents will be determined by the module receiving the notification. 
 
+* When specifying your cron values you'll need to make sure that your values fall within the ranges. For instance, some cron's use a 0-7 range for the day of week where both 0 and 7 represent Sunday. We do not. And that is an optimisation.
+
+| Seconds | 0-59 |
+| Minutes | 0-59 |
+| Hours | 0-23 |
+| Day of Month | 1-31 |
+| Months | 0-11 (Jan-Dec) |
+| Day of Week | 0-6 (Sun-Sat) |
+
 #### Scheduling Multiple Notifications
 Multiple `notification_schedule` definitions can be added using an array, e.g.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ To schedule the sending of a notification to other modules, add a `notification_
 * `payload` is optional and its contents will be determined by the module receiving the notification. 
 
 * When specifying your cron values you'll need to make sure that your values fall within the ranges. For instance, some cron's use a 0-7 range for the day of week where both 0 and 7 represent Sunday. We do not. And that is an optimisation.
-
+| **Unit** | **Format** |
+| --- | --- |
 | Seconds | 0-59 |
 | Minutes | 0-59 |
 | Hours | 0-23 |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Add the module to the modules array in the `config/config.js` file:
 | `animationSpeed` | 1000 | **Optional** The speed of the show and hide animations in milliseconds |
 | `notification_schedule` |  | **Optional** A single, or array of multiple definitions to schedule when notifications should be sent. See [Scheduling Notifications](#scheduling-notifications)  |
 | `global_schedule` |  | **Optional** A single, or array of multiple definitions to schedule when all modules should be shown/hidden/dimmed. See [Global Schedules](#global-schedules)  |
+| `uselock` | `true` | **Optional** If set to `false`, the scheduler does not lock the hidden modules. Other modules can then be used to show the modules even if they are hidden by the scheduler. |
 | `debug` | `true` | **Optional** Outputs messages to the console/log when set to `true` |
 
 ## Config Examples


### PR DESCRIPTION
Explanation:
If "uselock" is set to "false", the scheduler does not lock the hidden modules.

Let’s say you have "Joe’s" profile that don’t show the clock.
But Joe’s profile should only be shown between 07:00 to 15:00 on Mon-Fri or with Facial-Recognition or with MMM-TouchNavigation.

Then you have "Jane’s" profile that should show the clock but her profile is usually activated with Facial-Recognition or MMM-TouchNavigation.

So to show Joe’s profile at the correct times, you would schedule a group like this:
global_schedule: [
// Show modules with the class "Joe" at 07:00 and hide at 15:00 on Mondays to Fridays.
{from: '0 7 * * MON,TUE,WED,THU,FRI', to: '0 15 * * MON,TUE,WED,THU,FRI', groupClass: 'Joe'}

On the clock module you would set the class “Jane” and “Joe”.

The problem is, that when the Scheduler hides the clock, because Joe’s profile should not show the clock. Jane will not be able to see the clock either at those times, because the clock is “locked” by the Scheduler.

But, if you don’t set the “lock-string” with the scheduler, the clock module CAN be shown by Jane (another module).

I hope this makes sense. :)
