### PR TITLE
Turn off debug logging by default

### DIFF
--- a/MMM-ModuleScheduler.js
+++ b/MMM-ModuleScheduler.js
@@ -14,7 +14,7 @@ Module.register("MMM-ModuleScheduler", {
 		animationSpeed: 1000,
 		notification_schedule: false,
 		global_schedule: false,
-		debug: true,
+		debug: false,
 		uselock: true
 	},
 


### PR DESCRIPTION
Can I also make a suggestion that we switch the logging from `console.log` to internal logger?  That allows control of logging level from global config variables.  It's an easy fix.  If you approve I can create a PR.
@ianperrin 